### PR TITLE
handle more situations where config_id selection doesnt allow for boot

### DIFF
--- a/src/linodes/components/ConfigSelectModalBody.js
+++ b/src/linodes/components/ConfigSelectModalBody.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { push } from 'react-router-redux';
 
 import { ModalFormGroup, Radio } from 'linode-components/forms';
 import { FormModalBody } from 'linode-components/modals';
@@ -7,7 +8,6 @@ import { FormModalBody } from 'linode-components/modals';
 import { hideModal } from '~/actions/modal';
 import { rebootLinode } from '~/api/ad-hoc/linodes';
 import { dispatchOrStoreErrors } from '~/api/util';
-
 
 export default class ConfigSelectModalBody extends Component {
   constructor(props) {
@@ -31,12 +31,32 @@ export default class ConfigSelectModalBody extends Component {
     ]));
   }
 
+  onCreateConfig = () => {
+    const { dispatch, linode } = this.props;
+
+    return dispatch(push(`/linodes/${linode.label}/settings/advanced/configs/create`));
+  }
+
   render() {
     const { dispatch, linode, action, title } = this.props;
     const { errors, configId } = this.state;
 
     const buttonText = action === rebootLinode ? 'Reboot' : 'Power On';
     const buttonDisabledText = action === rebootLinode ? 'Rebooting' : 'Powering On';
+
+    if (Object.values(linode._configs.configs).length === 0) {
+      return (
+        <FormModalBody
+          onCancel={() => dispatch(hideModal())}
+          onSubmit={this.onCreateConfig}
+          buttonText="Create A Config"
+          buttonDisabledText={buttonDisabledText}
+        >
+          This Linode has no configuration profiles associated with it.
+          You must create one to boot this Linode.
+        </FormModalBody>
+      );
+    }
 
     return (
       <FormModalBody

--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
+import { FormGroup } from 'linode-components/forms';
 import { Dropdown } from 'linode-components/dropdowns';
 import { ConfirmModalBody, DeleteModalBody } from 'linode-components/modals';
 
@@ -161,15 +162,16 @@ export default class StatusDropdown extends Component {
     const configs = linode._configs.configs;
     const configCount = Object.keys(configs).length;
 
-    if (configCount <= 1) {
-      dispatch(callback(linode.id, parseInt(Object.keys(configs)[0]) || null));
-      dispatch(hideModal());
-      return;
+    if (configCount === 1) {
+      return dispatch(dispatchOrStoreErrors.call(this, [
+        () => callback(linode.id, parseInt(Object.keys(configs)[0]) || null),
+        () => hideModal(),
+      ]));
     }
 
     const title = 'Select Configuration Profile';
 
-    dispatch(showModal(title, (
+    return dispatch(showModal(title, (
       <ConfigSelectModalBody
         linode={linode}
         title={title}
@@ -232,6 +234,7 @@ export default class StatusDropdown extends Component {
 
   render() {
     const { linode } = this.props;
+    const { errors } = this.state;
 
     const groups = this.linodeToGroups(linode);
 
@@ -247,6 +250,7 @@ export default class StatusDropdown extends Component {
             className={`StatusDropdown-progress ${this.state.hiddenClass}`}
           />
         </div>
+        <FormGroup errors={errors} name="config_id" />
       </div>
     );
   }


### PR DESCRIPTION
This PR against linode/manager#2816 attempts to handle the problems described here: https://github.com/linode/manager/issues/2742#issuecomment-349510193

As far as I can tell, the FormGroup I attempted to add in this PR doesn't work.  The intent was to report that the config_id was invalid in cases where `config_id:null` (or an otherwise no longer config) was submitted to the boot endpoint (or to capture any other errors that boot could return).

Some of those errors will now be masked in most situations, however, by the following change:

- When no configs are present, the usual multi-config dialog informs the user to create a config.  This will occur when "Power On" is triggered with no configs.

![image](https://user-images.githubusercontent.com/317653/33642630-c1f8f6fa-da08-11e7-97a4-5c71fe28b2f1.png)


